### PR TITLE
Implement pedaling speed measure

### DIFF
--- a/pedaling_mgt/pedaling_mgt.c
+++ b/pedaling_mgt/pedaling_mgt.c
@@ -6,12 +6,24 @@
 
 #include "time_mgt.h"
 
+/**** Defines ****/
+
+#define SENSOR_MAGNET_COUNT 12U
+#define US_TO_MIN(x)        ((float)x/60e6)
+
+/**** Public variables ****/
+
+static uint32_t time_delta_magnet_us;
+
 /**** Public API ****/
 
 float get_pedaling_speed(void)
 {
-    // WRITE YOUR CODE HERE
-    return 0.f;
+    /* Between two magnets the crankset has rotated of 1.0/SENSOR_MAGNET_COUNT turn
+       and it took time_delta microseconds. So we can calculate te current pedaling speed :
+       RPM = 1 / (time_delta_magnet_minute * SENSOR_MAGNET_COUNT) 
+    */
+    return 1.0F / (US_TO_MIN((float)time_delta_magnet_us) * (float)SENSOR_MAGNET_COUNT);
 }
 
 float get_average_pedaling_speed(void)
@@ -22,5 +34,21 @@ float get_average_pedaling_speed(void)
 
 void new_magnet_cb(void)
 {
-    // WRITE YOUR CODE HERE
+    static uint32_t previous_timestamp = 0UL;
+    uint32_t current_timestamp = 0UL;
+
+    current_timestamp = get_timestamp();
+
+    /* Compute elapsed time since last magnet detection */
+    if(current_timestamp < previous_timestamp) /* timestamp overflow */
+    {
+        time_delta_magnet_us = UINT32_MAX - previous_timestamp + current_timestamp;
+    }
+    else
+    {
+        time_delta_magnet_us = current_timestamp - previous_timestamp;     
+    }
+
+    /* Store previous timestamp for next magnet computation */
+    previous_timestamp = current_timestamp;
 }

--- a/pedaling_mgt/pedaling_mgt.c
+++ b/pedaling_mgt/pedaling_mgt.c
@@ -14,30 +14,52 @@
 /**** Public variables ****/
 
 static uint32_t time_delta_magnet_us;
+static uint32_t time_delta_turn_us;
 
 /**** Public API ****/
 
 float get_pedaling_speed(void)
 {
-    /* Between two magnets the crankset has rotated of 1.0/SENSOR_MAGNET_COUNT turn
-       and it took time_delta microseconds. So we can calculate te current pedaling speed :
-       RPM = 1 / (time_delta_magnet_minute * SENSOR_MAGNET_COUNT) 
+    /* Between two magnets the crankset has rotated of 1.0/SENSOR_MAGNET_COUNT
+       turn and it took time_delta microseconds. So we can calculate te current
+       pedaling speed :
+       RPM = 1 / (time_delta_magnet_minute * SENSOR_MAGNET_COUNT)
     */
     return 1.0F / (US_TO_MIN((float)time_delta_magnet_us) * (float)SENSOR_MAGNET_COUNT);
 }
 
 float get_average_pedaling_speed(void)
 {
-    // WRITE YOUR CODE HERE
-    return 0.f;
+    /* The average pedaling speed on the previous turn is simply
+       the inverse of the time (in minute) elapased during the last turn
+    */
+    return 1.0F / US_TO_MIN((float)time_delta_turn_us);
 }
 
 void new_magnet_cb(void)
 {
+    static uint8_t magnet_count = 0U;
+    static uint32_t timestamps[SENSOR_MAGNET_COUNT] = {0UL};
     static uint32_t previous_timestamp = 0UL;
+    uint32_t oldest_timestamp = 0UL;
     uint32_t current_timestamp = 0UL;
 
+    /* Circular buffer to compute average pedaling speed */
+    if(magnet_count >= (SENSOR_MAGNET_COUNT - 1U))
+    {
+        oldest_timestamp = timestamps[0];
+        magnet_count = 0U;
+    }
+    else
+    {
+        magnet_count++;
+        oldest_timestamp = timestamps[magnet_count];
+    }
+
     current_timestamp = get_timestamp();
+
+    /* Store the current timestamp for next turn computation */
+    timestamps[magnet_count] = current_timestamp;
 
     /* Compute elapsed time since last magnet detection */
     if(current_timestamp < previous_timestamp) /* timestamp overflow */
@@ -47,6 +69,16 @@ void new_magnet_cb(void)
     else
     {
         time_delta_magnet_us = current_timestamp - previous_timestamp;     
+    }
+
+    /* Compute elapsed time during the last full crankset turn */
+    if(current_timestamp < oldest_timestamp) /* timestamp overflow */
+    {
+        time_delta_turn_us = UINT32_MAX - oldest_timestamp + current_timestamp;
+    }
+    else
+    {
+        time_delta_turn_us = current_timestamp - oldest_timestamp;
     }
 
     /* Store previous timestamp for next magnet computation */

--- a/pedaling_mgt/pedaling_mgt.h
+++ b/pedaling_mgt/pedaling_mgt.h
@@ -13,6 +13,8 @@ float get_pedaling_speed(void);
 
 /**
  * @brief Return average current pedaling speed in RPM
+ *
+ * @note At least one turn of crankset must be done to get an accurate value
  */
 float get_average_pedaling_speed(void);
 


### PR DESCRIPTION
* Three functions are added to calculate both instantaneous and average pedaling speed using the callback triggered by the 12 PAS magnetic sensor. 

* The instantaneous speed is calculated with the time elapsed between two magnets detection. Whereas the average pedaling speed is calculated using the time elapsed between the detection of the same magnet after one full turn of crankset. 

* For simplification of the code and the performance considerations, the first turn of crankset after code initialization doesn't give the a proper reading. This choice could be changed if correct reading is needed immediately after software start.